### PR TITLE
Fix gallery alignment for sur-mesure section

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
     </section>
 
     <!-- ====== Bloc 2 : texte à gauche / photos à droite ====== -->
-    <section class="stack-area reverse" style="margin-top:26px">
+    <section class="stack-area" style="margin-top:26px">
       <div class="card">
         <h2>Création de votre site internet sur-mesure</h2>
         <p class="lead">Accompagnement dédié, du brief à la mise en ligne.</p>


### PR DESCRIPTION
## Summary
- remove the reverse flex direction from the sur-mesure section so the gallery sits to the right of the text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd7d242b108333afd7a6665f8dfa43