### PR TITLE
Add fan-out hover transforms for image stacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,9 @@
     .shot:nth-child(3){transform:rotate(5deg) translate(14px,-10px) scale(.985); z-index:1;}
     .shot img{width:100%;height:100%;object-fit:cover;display:block;opacity:.92; transition:opacity .4s ease}
     .stack:hover .shot{box-shadow:0 18px 40px rgba(0,0,0,.55), 0 0 0 1px rgba(255,255,255,.09) inset}
+    .stack:hover .shot:nth-child(1){transform:translate3d(-46px,22px,0) rotate(-12deg) scale(.975)}
+    .stack:hover .shot:nth-child(2){transform:translate3d(0,-10px,0) rotate(0deg) scale(1.015)}
+    .stack:hover .shot:nth-child(3){transform:translate3d(46px,-24px,0) rotate(11deg) scale(.975)}
     .stack:hover .shot img{opacity:1}
 
     /* Expansion + overlay */


### PR DESCRIPTION
## Summary
- add per-image hover transforms to fan out stacked photos
- preserve existing transitions so the lightbox expansion remains unaffected

## Testing
- manual test: hovered both image stacks in browser


------
https://chatgpt.com/codex/tasks/task_e_68dd822ca1f08333bd077ac945f9507c