### PR TITLE
Remove tax credit badge from column 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,15 +260,6 @@
           </td>
           <td class="wide-column column-2">
   <div class="services-tooltip-container-wrapper">
-    <!-- Première image avec sa propre infobulle -->
-    <div class="services-tooltip-container">
-      <img src="https://sapconseils.fr/wp-content/uploads/93.jpg" alt="Crédit d'impôt professionnel"
-           class="wide-column">
-      <div class="services-tooltip">
-        -25% de crédit d'impôt SAP pour les entreprises
-      </div>
-    </div>
-
     <!-- Deuxième image avec une infobulle différente -->
     <div class="services-tooltip-container">
       <img src="https://sapconseils.fr/wp-content/uploads/94.jpg"


### PR DESCRIPTION
### Motivation
- Remove the enterprise tax credit badge shown in column 2, row 2 to reflect updated content requirements.
- Keep the remaining badge (advance immédiate) in place so the column retains the intended secondary indicator.

### Description
- Deleted the first `.services-tooltip-container` inside the column-2 badge wrapper that rendered `-25% de crédit d'impôt SAP pour les entreprises` in `index.html`.
- Preserved the second badge (`Avance Immédiate au crédit d'impôt`) and left layout/JS logic unchanged.
- Only `index.html` was modified.

### Testing
- Rendered the updated page by serving with `python -m http.server 8000` and captured a full-page screenshot with a Playwright script to verify the badge is removed, producing `artifacts/column2-badge-removed.png`.
- No automated unit tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f224ca10833384ebd95c0a82a556)