### PR TITLE
Render default table on load; update Standard Téléphonique and remove tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,9 +353,9 @@
             </div>
           </td>
           <td class="column-2">
-            <div class="services-tooltip-container">8h - 19h
+            <div class="services-tooltip-container">8h - 20h
               <div class="services-tooltip">
-                Ouvert de 8h à 19h<br>
+                Ouvert le samedi<br>
               </div>
             </div>
           </td>
@@ -580,11 +580,7 @@
             </div>
           </td>
           <td class="column-2">
-            <div class="services-tooltip-container">2
-              <div class="services-tooltip">
-                Avance immédiate = 7
-              </div>
-            </div>
+            <div class="services-tooltip-container">2</div>
           </td>
           <td>
             <div class="services-tooltip-container">2</div>
@@ -698,6 +694,7 @@
 
         assujettiSelect.addEventListener('change', updateResult);
         tvaTauxSelect.addEventListener('change', updateResult);
+        updateResult();
     </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Ensure the services comparison table is visible immediately on page load using the current select values (`Oui` / `20%`).
- Update the displayed hours and tooltip for the “Standard Téléphonique” cell to reflect the correct schedule.
- Remove an unnecessary tooltip from the “Délai de rétribution” cell to simplify the UI.
- Improve UX by showing results without requiring user interaction with the selects.

### Description
- Call `updateResult()` at the end of the script so the table is rendered on initial load.
- Change the “Standard Téléphonique” cell content from `8h - 19h` to `8h - 20h` and update its tooltip text to `Ouvert le samedi`.
- Remove the nested tooltip `div` from the `Délai de rétribution` column 2 cell so it now contains a plain `2` value.
- Adjusted HTML markup accordingly in `index.html` to reflect these content changes.

### Testing
- Served the site with `python -m http.server 8000` and successfully served `index.html` for browser testing.
- Ran a Playwright script to load the page and capture a screenshot (`artifacts/table.png`), which completed successfully.
- No unit tests were executed for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696566a961c08333bf3b55f7bd92daae)