### PR TITLE
Update Offre 5 column to match Column 2 content

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,11 +336,21 @@
         Vos clients règlent 50% du montant de la facture !
       </div>
     </div>
-  </div>
+          </div>
 </td>
           <td>
-            <div class="gray-check"></div>
-          </td>
+  <div class="services-tooltip-container-wrapper">
+    <!-- Deuxième image avec une infobulle différente -->
+    <div class="services-tooltip-container">
+      <img src="https://sapconseils.fr/wp-content/uploads/94.jpg"
+           alt="Avance Immédiate au crédit d'impôt"
+           class="wide-column">
+      <div class="services-tooltip">
+        Vos clients règlent 50% du montant de la facture !
+      </div>
+    </div>
+  </div>
+</td>
         </tr>
 
         <tr>
@@ -377,7 +387,11 @@
             <div class="services-tooltip-container"> 8H - 20H</div>
           </td>
           <td>
-            <div class="gray-check">✔</div>
+            <div class="services-tooltip-container">8h - 20h
+              <div class="services-tooltip">
+                Ouvert le samedi<br>
+              </div>
+            </div>
           </td>
         </tr>
 
@@ -408,7 +422,7 @@
             </div>
           </td>
           <td>
-            <div class="gray-check">-</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
 
@@ -439,7 +453,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">✔</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
 
@@ -465,7 +479,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">✔</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
          <tr>
@@ -490,7 +504,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">✔</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
 
@@ -515,7 +529,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">✔</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
 
@@ -565,7 +579,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">✔</div>
+            <div class="gray-check">-</div>
           </td>
         </tr>
 
@@ -592,7 +606,7 @@
             <div class="services-tooltip-container">2</div>
           </td>
           <td>
-            <div class="gray-check">-</div>
+            <div class="services-tooltip-container">2</div>
           </td>
         </tr>
 
@@ -617,7 +631,7 @@
             <div class="services-tooltip-container">0%</div>
           </td>
           <td>
-            <div class="gray-check">12%</div>
+            <div class="gray-check">10%</div>
           </td>
         </tr>
 
@@ -643,7 +657,7 @@
             <div class="services-tooltip-container">${tvaValues[3]}</div>
           </td>
           <td>
-            <div class="gray-check">${tvaValues[4]}</div>
+            <div class="gray-check">${tvaValues[0]}</div>
           </td>
         </tr>
 
@@ -669,7 +683,7 @@
             <div class="services-tooltip-container">47,99 € / mois</div>
           </td>
           <td>
-            <div class="gray-check">50€ / an</div>
+            <div class="gray-check">-</div>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
### Motivation
- Align the "Offre 5" column with the data shown in column 2 (images, tooltips, availability, checks, commission, TVA and fixed fees) to keep the table consistent across offers.
- The change was intended to source column 2 content from the referenced CodePen, but outbound access to CodePen returned HTTP 403, so the repository's existing column 2 content was used as the source.

### Description
- Replaced the HTML cells under the `Offre 5` column with the same markup and values used in column 2, including images and tooltip containers for the top rows. 
- Updated service availability cells to show identical hours/tooltip content as column 2 and converted several `gray-check` cells to `green-check` where column 2 had checks. 
- Normalized commission and TVA/frais fixes rows to match column 2 values and changed the TVA display for `Offre 5` from `${tvaValues[4]}` to `${tvaValues[0]}`. 
- Committed the updated `index.html` file with the adjusted Offer 5 column markup and values.

### Testing
- Launched a local static server with `python -m http.server 8000` and confirmed the page served successfully. 
- Ran a Playwright script to render the updated page and saved a full-page screenshot to `artifacts/offre-5-update.png`, which completed successfully. 
- Performed a local commit with `git commit` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69675ae86cf483338b8f0e755ebb1dac)