### PR TITLE
Update Offre 5 column: ADOM logo, badges, checkmarks, hours, commission and TVA mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,16 @@
             height: auto;
         }
 
+        .badge-text {
+            background-color: #f4f4f4;
+            border-radius: 12px;
+            color: #333;
+            display: inline-block;
+            font-size: 12px;
+            padding: 6px 10px;
+            text-align: center;
+        }
+
         .services-tooltip-container-wrapper {
             display: flex;
             align-items: center;
@@ -226,11 +236,11 @@
 
         const tvaValuesBySelection = {
             'non|20%': ['20%', '0%', '0%', '20%', '20%'],
-            'non|10%': ['10%', '0%', '0%', '10%', '20%'],
-            'non|5.5%': ['20%', '0%', '0%', '5,5%', '20%'],
+            'non|10%': ['10%', '0%', '0%', '10%', '10%'],
+            'non|5.5%': ['20%', '0%', '0%', '5,5%', '5,5%'],
             'oui|20%': ['20%', '20%', '20%', '20%', '20%'],
-            'oui|10%': ['10%', '10%', '10%', '10%', '20%'],
-            'oui|5.5%': ['20%', '5,5%', '5,5%', '5,5%', '20%']
+            'oui|10%': ['10%', '10%', '10%', '10%', '10%'],
+            'oui|5.5%': ['20%', '5,5%', '5,5%', '5,5%', '5,5%']
         };
 
         const tableTemplate = (tvaValues, isColumn2Gray) => `
@@ -246,7 +256,7 @@
 
           <th class="wide-column"><img src="https://unipros.coop/wp-content/uploads/2023/03/unipros-cooperative-sap-logo-fond-clair.png" alt="UNIPROS" class="logo-img"></th>
 
-          <th>Offre 5</th>
+          <th class="wide-column"><img src="https://www.adomsap.fr/wp-content/uploads/2025/04/Logo-Adom-SVG-1.svg" alt="ADOM" class="logo-img"></th>
         </tr>
       </thead>
       <tbody>
@@ -338,8 +348,15 @@
     </div>
   </div>
 </td>
-          <td>
-            <div class="gray-check"></div>
+          <td class="wide-column">
+            <div class="services-tooltip-container-wrapper">
+              <div class="services-tooltip-container">
+                <span class="badge-text">-25% de crédit d'impot SAP pour les entreprises</span>
+              </div>
+              <div class="services-tooltip-container">
+                <span class="badge-text">vos clients règlent 50% du montant de la facture</span>
+              </div>
+            </div>
           </td>
         </tr>
 
@@ -377,7 +394,11 @@
             <div class="services-tooltip-container"> 8H - 20H</div>
           </td>
           <td>
-            <div class="gray-check">✔</div>
+            <div class="services-tooltip-container">8H - 19H
+              <div class="services-tooltip">
+                Samedi : 9H-13H
+              </div>
+            </div>
           </td>
         </tr>
 
@@ -408,7 +429,7 @@
             </div>
           </td>
           <td>
-            <div class="gray-check">-</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
 
@@ -439,7 +460,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">✔</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
 
@@ -465,7 +486,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">✔</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
          <tr>
@@ -490,7 +511,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">✔</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
 
@@ -515,7 +536,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">✔</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
 
@@ -565,7 +586,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">✔</div>
+            <div class="gray-check">-</div>
           </td>
         </tr>
 
@@ -592,7 +613,7 @@
             <div class="services-tooltip-container">2</div>
           </td>
           <td>
-            <div class="gray-check">-</div>
+            <div class="services-tooltip-container">1 à 2.</div>
           </td>
         </tr>
 
@@ -617,7 +638,12 @@
             <div class="services-tooltip-container">0%</div>
           </td>
           <td>
-            <div class="gray-check">12%</div>
+            <div class="services-tooltip-container">
+              5% <span class="orange-text"> (↘)</span>
+              <div class="services-tooltip">
+                Taux dégressif jusqu'à 3%<br>
+              </div>
+            </div>
           </td>
         </tr>
 
@@ -669,7 +695,7 @@
             <div class="services-tooltip-container">47,99 € / mois</div>
           </td>
           <td>
-            <div class="gray-check">50€ / an</div>
+            <div class="gray-check">-</div>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
### Motivation
- Bring the "Offre 5" column in the services comparison table in line with the requested content and visual cues (ADOM logo, badges, tooltips, green checks and commission display). 
- Ensure the TVA cell for the last column reflects the user selection from the TVA dropdown.

### Description
- Replaced the "Offre 5" header text with the ADOM logo (`https://www.adomsap.fr/.../Logo-Adom-SVG-1.svg`) and added a `.badge-text` CSS class for inline badge styling. 
- Added two badge texts in the Offre 5 column: `-25% de crédit d'impot SAP pour les entreprises` and `vos clients règlent 50% du montant de la facture`. 
- Updated the telephone hours cell to `8H - 19H` with an infobubble showing `Samedi : 9H-13H`. 
- Converted several Offre 5 cells from gray `-` to green `✔` where requested (attestations, apport de clients, espace en ligne, relance impayées, aide au recouvrement, etc.). 
- Set the Délai de rétribution cell to `1 à 2.` and replaced the commission cell with the services-tooltip showing `5% (↘)` and a tooltip `Taux dégressif jusqu'à 3%`. 
- Removed the previous `50€ / an` fixed fee and replaced it with `-`. 
- Adjusted the `tvaValuesBySelection` mapping so the last column (Offre 5) displays the selected TVA rate (20%, 10% or 5.5%) consistently for both `assujetti` = `oui` and `non`. 

### Testing
- Started a local HTTP server (`python -m http.server 8000`) and rendered the updated page in a headless browser; a full-page screenshot was generated via Playwright and the script completed successfully. 
- No unit tests were present or run for this change; the update is a static markup/CSS/JS modification and was committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696762bdb0ec833391441da0b072676a)