### PR TITLE
Update service hours, tooltips and column indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,31 +382,39 @@
             </div>
           </td>
           <td class="column-2">
-            <div class="services-tooltip-container">8h - 20h
+            <div class="services-tooltip-container">8h - 19h
               <div class="services-tooltip">
                 Ouvert le samedi<br>
               </div>
             </div>
           </td>
           <td>
-            <div class="services-tooltip-container"> 9h - 20h
+            <div class="services-tooltip-container"> 8h - 19h
               <div class="services-tooltip">
                 Ouvert le samedi<br>
               </div>
             </div>
           </td>
           <td>
-            <div class="services-tooltip-container"> 9H30 - 12H30 <br> 13H30 - 16H30
+            <div class="services-tooltip-container"> 9h30 - 12h30 <br> 13h30 - 16h30
               <div class="services-tooltip">
                 Fermé le Mercredi<br>
               </div>
             </div>
           </td>
           <td>
-            <div class="services-tooltip-container"> 8H - 20H</div>
+            <div class="services-tooltip-container"> 8h - 19h
+              <div class="services-tooltip">
+                Ouvert le samedi<br>
+              </div>
+            </div>
           </td>
           <td>
-            <div class="services-tooltip-container">8H - 20H</div>
+            <div class="services-tooltip-container">8h - 19h
+              <div class="services-tooltip">
+                Samedi : 9h -13h<br>
+              </div>
+            </div>
           </td>
         </tr>
 
@@ -544,7 +552,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="green-check">✔</div>
+            <div class="gray-check">-</div>
           </td>
         </tr>
 
@@ -569,7 +577,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">-</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
 
@@ -594,7 +602,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">-</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
 


### PR DESCRIPTION
### Motivation
- Align displayed service hours and tooltips for the comparison table to updated business requirements and correct hour formatting.
- Clarify availability details on Saturdays for the last column and ensure visual indicators match the requested availability state.

### Description
- Updated hours and tooltips in `index.html` for the "Standard Téléphonique" row: column 2 set to `8h - 19h`, column 3 set to `8h - 19h`, column 4 set to `9h30 - 12h30 / 13h30 - 16h30`, column 5 tooltip set to `Ouvert le samedi`, and column 6 set to `8h - 19h` with tooltip `Samedi : 9h -13h`.
- Normalized all hour markings in the "Standard Téléphonique" row and its tooltips to lowercase `h` (e.g. `8h - 19h`).
- Adjusted column-6 indicators: changed "Aide au recouvrement des créances" in column 6 to a gray dash (`-`) and set "Aide/Outils de communication" in column 6 to a green check (`✔`).
- Changes are purely static HTML updates within the `table` markup in `index.html` and styling uses existing `green-check` / `gray-check` classes.

### Testing
- Committed the changes to the repository with `git commit` and updated `index.html` successfully.
- Attempted to capture a visual screenshot via Playwright to validate rendering, but the headless browser failed to launch (environment `BrowserType.launch` error / SIGSEGV), so the screenshot step failed.
- No automated unit tests were executed for these static content changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69679082fc44833388c9e0abc679c42b)