### PR TITLE
Fix Service Juridique column 6 and restore adjacent row indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,7 +552,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="gray-check">-</div>
+            <div class="green-check">✔</div>
           </td>
         </tr>
 
@@ -577,7 +577,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="green-check">✔</div>
+            <div class="gray-check">-</div>
           </td>
         </tr>
 


### PR DESCRIPTION
### Motivation
- Correct the earlier change that modified the wrong row and apply the requested state to the "Service Juridique" row (column 6) so it shows a gray dash.
- Ensure the adjacent "Aide au recouvrement des créances" row keeps its intended column 6 checkmark.

### Description
- Updated `index.html` to set the column 6 indicator for the "Service Juridique" row to `<div class="gray-check">-</div>`.
- Restored the column 6 indicator for the "Aide au recouvrement des créances" row to `<div class="green-check">✔</div>`.
- Changes are simple HTML swaps between `<div class="green-check">✔</div>` and `<div class="gray-check">-</div>` in the relevant table rows.

### Testing
- Launched a local static server with `python -m http.server` and attempted to capture a screenshot with Playwright, but Chromium crashed in the environment so no screenshot was produced.
- Verified the modified `index.html` content with file inspection and local rendering attempts; no automated test suite was run beyond the screenshot attempt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696793ea11cc8333b01176bd69892001)