### PR TITLE
Update Adom column values from index2 column 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,15 +306,6 @@
 </td>
           <td class="wide-column">
   <div class="services-tooltip-container-wrapper">
-    <!-- Première image avec sa propre infobulle -->
-    <div class="services-tooltip-container">
-      <img src="https://sapconseils.fr/wp-content/uploads/93.jpg" alt="Crédit d'impôt professionnel"
-           class="wide-column">
-      <div class="services-tooltip">
-        -25% de crédit d'impôt SAP pour les entreprises
-      </div>
-    </div>
-
     <!-- Deuxième image avec une infobulle différente -->
     <div class="services-tooltip-container">
       <img src="https://sapconseils.fr/wp-content/uploads/94.jpg"
@@ -406,7 +397,11 @@
             <div class="services-tooltip-container"> 8H - 20H</div>
           </td>
           <td>
-            <div class="services-tooltip-container">8H - 20H</div>
+            <div class="services-tooltip-container"> 8h - 19h
+              <div class="services-tooltip">
+                Samedi : 9h - 13h<br>
+              </div>
+            </div>
           </td>
         </tr>
 
@@ -437,7 +432,7 @@
             </div>
           </td>
           <td>
-            <div class="green-check">✔</div>
+            <div class="services-tooltip-container">✔</div>
           </td>
         </tr>
 
@@ -468,7 +463,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="green-check">✔</div>
+            <div class="services-tooltip-container">✔</div>
           </td>
         </tr>
 
@@ -494,7 +489,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="green-check">✔</div>
+            <div class="services-tooltip-container">✔</div>
           </td>
         </tr>
          <tr>
@@ -519,7 +514,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="green-check">✔</div>
+            <div class="services-tooltip-container">✔</div>
           </td>
         </tr>
 
@@ -544,7 +539,7 @@
             <div class="services-tooltip-container">✔</div>
           </td>
           <td>
-            <div class="green-check">✔</div>
+            <div class="gray-check">-</div>
           </td>
         </tr>
 
@@ -621,7 +616,7 @@
             <div class="services-tooltip-container">2</div>
           </td>
           <td>
-            <div class="services-tooltip-container green-check">2</div>
+            <div class="services-tooltip-container">1 à 2</div>
           </td>
         </tr>
 
@@ -646,7 +641,12 @@
             <div class="services-tooltip-container">0%</div>
           </td>
           <td>
-            <div class="services-tooltip-container green-check">3 à 5%</div>
+            <div class="services-tooltip-container">
+              5% <span class="orange-text"> (↘)</span>
+              <div class="services-tooltip">
+                Taux dégressif jusqu'à 3%<br>
+              </div>
+            </div>
           </td>
         </tr>
 
@@ -672,7 +672,7 @@
             <div class="services-tooltip-container">${tvaValues[3]}</div>
           </td>
           <td>
-            <div class="green-check">${tvaValues[4]}</div>
+            <div class="services-tooltip-container">20%</div>
           </td>
         </tr>
 


### PR DESCRIPTION
### Motivation
- Align the Adom (sixth) column in the comparison table with the values present in column 2 of `index2.html` to keep both tables consistent.

### Description
- Update the Adom hero image/tooltip in `index.html` to match the source image and tooltip from `index2.html`.
- Change the Adom "Standard Téléphonique" cell to `8h - 19h` and add the Saturday hours tooltip to match the source.
- Replace several `green-check` entries with `services-tooltip-container` or `gray-check` where the source uses different markers, and adjust availability markers accordingly.
- Sync Adom values for `Délai de rétribution`, `Commission` and `TVA` cells to the values present in column 2 of `index2.html`.

### Testing
- Started a local static server with `python -m http.server` and captured a full-page screenshot using Playwright as a visual smoke test, which completed successfully.
- No unit tests or automated integration tests were run against this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967a06df11c8333845b3cbcbd8791f0)